### PR TITLE
Fixed token parsing issue causeing the tokens were null error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Files of Project Spark game are intercompatible between Xbox and PC versions. yo
 
 ### known issues:
 * kinect captures directly taken from xbox wont work in PC but if they are converted into brains or assemblies, they work
-* sometimes, app gets confiused when there are multiple saved credentials with the same name. a guide on how to get the app working is being written while a fix for this issue is found.
+* ~~sometimes, app gets confiused when there are multiple saved credentials with the same name. a guide on how to get the app working is being written while a fix for this issue is found.~~ (this issue is fixed)
 
 ## How to use:
 1. Download the latest release from [github](https://github.com/ProjectSparkDev/ProjectSparkBatchSaveDownloader/releases)


### PR DESCRIPTION
using the tags provided in the names of xbox live credentials stored in the windows, we can reconstruct and merge the split tokens saved in multiple entries.
later a user select system can be added using the full tokens. for now its just first token  available.